### PR TITLE
fix: Metatag 'twitter:image:alt' linkt niet naar bestaand plaatje

### DIFF
--- a/_data/translations.yml
+++ b/_data/translations.yml
@@ -12,8 +12,9 @@ head-social-og-image-url:
   nl: img/head-social-og-image--nl.png
   en: img/head-social-og-image--nl.png
 head-social-og-image-alt:
-  nl: Impressie van website waarop toelichting te vinden is
-  en: TBD
+  # Relative url e.g.: img/social.png
+  nl: img/app-preview.png
+  en: img/app-preview.png
 
 page-title:
   nl: De CoronaMelder app is in ontwikkeling

--- a/_data/translations.yml
+++ b/_data/translations.yml
@@ -12,9 +12,8 @@ head-social-og-image-url:
   nl: img/head-social-og-image--nl.png
   en: img/head-social-og-image--nl.png
 head-social-og-image-alt:
-  # Relative url e.g.: img/social.png
-  nl: img/app-preview.png
-  en: img/app-preview.png
+  nl: Impressie van website waarop toelichting te vinden is
+  en: TBD
 
 page-title:
   nl: De CoronaMelder app is in ontwikkeling

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -17,14 +17,14 @@
 
     <meta property="og:site_name" content="{{ site.data.translations.head-social-og-site_name[page.lang] }}">
     <meta property="og:title" content="{{ site.data.translations.head-social-og-title[page.lang] }}" />
-    <meta property="og:description" content="{{ site.data.translations.head-social-og-description[page.lang]}}"/>
-    <meta property="og:image" itemprop="image" content="{{ relroot }}{{ site.data.translations.head-social-og-image-url[page.lang]}}">
+    <meta property="og:description" content="{{ site.data.translations.head-social-og-description[page.lang] }}"/>
+    <meta property="og:image" itemprop="image" content="{{ relroot }}{{ site.data.translations.head-social-og-image-url[page.lang] }}">
     <meta property="og:updated_time" content="{{ site.time | date: "%s" }}" />
     <meta property="og:type" content="website" />
 
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="{{ site.data.translations.head-social-og-title[page.lang] }}" />
-    <meta name="twitter:description" content="{{ site.data.translations.head-social-og-description[page.lang]}}" />
-    <meta name="twitter:image" content="https://coronamelder.nl/{{ site.data.translations.head-social-og-image-url[page.lang]}}" />
-    <meta name="twitter:image:alt" content="https://coronamelder.nl/{{ site.data.translations.head-social-og-image-alt[page.lang]}}" />
+    <meta name="twitter:description" content="{{ site.data.translations.head-social-og-description[page.lang] }}" />
+    <meta name="twitter:image" content="https://coronamelder.nl/{{ site.data.translations.head-social-og-image-url[page.lang] }}" />
+    <meta name="twitter:image:alt" content="{{ site.data.translations.head-social-og-image-alt[page.lang] }}" />
 </head>


### PR DESCRIPTION
De huidige meta tag `twitter:image:alt` ziet er als volgt uit:
```<meta name="twitter:image:alt" content="https://coronamelder.nl/Impressie van website waarop toelichting te vinden is">```

Dit is opgelost in deze commit.