### PR TITLE
2020-07-31: Deactivate Piwik & Update cookies page (commit signed...)

### DIFF
--- a/_includes/faq.html
+++ b/_includes/faq.html
@@ -43,6 +43,7 @@
                   {{ question.content }}
                 </div>
 
+                {%- comment -%}
                 <div class="feedback">{% comment %} Note hidden by default. Can only be used when js-enabled. {% endcomment %}
                   <div class="feedback__question" data-js-stats-event='["trackEvent", "feedback", "faq - {{ question.title }}", "--statsFeedback--"]'>
                     <h5>{{ site.data.translations.has-been-answered[page.lang] }}</h5>
@@ -71,6 +72,7 @@
                   </div>
                 </div>
               </div>
+              {%- endcomment -%}
 
             </details>
           {% endfor %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -10,9 +10,11 @@
     <link href="{{ relroot }}img/favicon.ico" rel="shortcut icon" type="image/x-icon">
     <link rel="stylesheet" href="{{ relroot }}js/vendors/swiper-bundle.5.4.5.min.css" crossorigin="anonymous">
     <script src="{{ relroot }}js/vendors/swiper-bundle.5.4.5.min.js" crossorigin="anonymous"></script>
+    {%- comment -%}
     <script src="{{ relroot }}js/piwik.js?v={{ timeslug }}" crossorigin="anonymous" async></script>
     <script src="{{ relroot }}js/stats.js?v={{ timeslug }}" crossorigin="anonymous" async></script>
-    
+    {%- endcomment -%}
+
     <meta name="description" content="{{ site.data.translations.head-social-og-description[page.lang]}}">
 
     <meta property="og:site_name" content="{{ site.data.translations.head-social-og-site_name[page.lang] }}">

--- a/cookies.md
+++ b/cookies.md
@@ -8,53 +8,8 @@ permalink: /cookies
 
 # Cookies
 
-Coronamelder.nl maakt gebruik van cookies en webstatistieken. Hieronder leest u waarom. En u ziet welke cookies Coronamelder.nl precies plaatst en met welk doel.
-
-Op cookies zijn 2 wetten van toepassing:
-
-1. Algemene Verordening Gegevensbescherming
-2. Telecomwet
-
-## Algemene Verordening Gegevensbescherming
-
-Coronamelder.nl gebruikt cookies voor onderzoek en webstatistieken om te begrijpen hoe bezoekers de website gebruiken. Deze informatie helpt de website te verbeteren. Bijvoorbeeld door informatie aan te vullen of door het gebruikersgemak te vergroten.
-
-Het ministerie van Volksgezondheid, Welzijn en Sport heeft maatregelen getroffen om de herleidbaarheid van bezoekers aan onze website zo veel mogelijk te beperken. Dit doen we door onmiddellijk na het importeren van de logfiles in Piwik het laatste octet (cijfergroep) van elk IP-adres weg te gooien. Dit gebeurt in een tijdelijk geheugen, voordat de IP-adressen in Piwik worden opgeslagen. Hierna is er geen sprake van verwerking van persoonsgegevens meer, omdat wij geen persoonsgegevens in ons bezit hebben.
-Wij verzamelen de volgende gegevens in Piwik:
-
-- gebruikte apparatuur en software (apparaten, browsers, besturingssysteem)
-- gebruikte links om op onze website te komen
-- gebruikte links binnen de website
-- gebruikte zoektermen in de zoekmachine op de website zelf
-
-Wij verstrekken geen persoonsgegevens aan derden, tenzij dat noodzakelijk is om aangifte te doen van strafbare feiten.
-
-## Telecomwet
-
-### Cookies voor webstatistieken
-
-In algemene zin is het zo dat websites bezoekers toestemming moeten vragen voor het plaatsen van cookies. De cookiewet maakt een uitzondering voor cookies die niet privacygevoelig zijn. Bijvoorbeeld voor cookies die bezoekersaantallen bijhouden.
-
-Voor cookies die geen of weinig inbreuk op de privacy maken, is geen toestemming van de bezoeker nodig. Dit zijn vaak cookies die een website beter laten werken. In deze categorie vallen ook onze analytische cookies. Websites gebruiken analytische cookies om bijvoorbeeld bezoekersstatistieken bij te houden. Zo krijgen zij beter inzicht in het functioneren van de website. Analytische cookies hebben nauwelijks gevolgen voor de privacy.
-
-Coronamelder.nl gebruikt cookies voor onderzoek en webstatistieken om te begrijpen hoe bezoekers de website gebruiken. Deze informatie helpt de site te verbeteren. Bijvoorbeeld door informatie aan te vullen of door het gebruikersgemak te verbeteren.
-
-Coronamelder.nl heeft maatregelen getroffen om de herleidbaarheid van bezoekers aan onze website zo veel mogelijk te beperken. Dit doen we door onmiddellijk in het webstatistiekprogramma Piwik het laatste octet (cijfergroep) van elk IP-adres weg te gooien. Dit gebeurt in een tijdelijk geheugen, voordat de IP-adressen in Piwik worden opgeslagen.
-
-Wij verzamelen de volgende gegevens in Piwik:
-
-- gebruikte apparatuur en software (apparaten, browsers, besturingssysteem)
-- gebruikte links om op onze website te komen
-- gebruikte links binnen de website
-- gebruikte zoektermen in de zoekmachine op de website zelf
-
-De verzamelde gegevens gebruikt Coronamelder.nl niet voor een ander doel dan voor verbetering van de website. In onderstaande tabel ziet u welke cookies verband houden met webstatistieken op Coronamelder.nl.
-
-| Naam cookie | Doel |
-|-------------|------|
-| Cookie_pk_id | Is de bezoeker nieuw of heeft de bezoeker de site al eerder bezocht? |
-| Cookie_pk_ses | Welke pagina's heeft de bezoeker geraadpleegd? |
-| Cookie_pk_ref | Vanaf welke site is de bezoeker gekomen? |
+Deze website gebruikt geen cookies om webstatistieken te meten. 
 
 ## Geen trackingcookies
+
 Trackingcookies zijn cookies die bezoekers tijdens het surfen over andere websites kunnen volgen. Coronamelder.nl gebruikt geen trackingcookies. De website biedt daarom geen ondersteuning voor de DoNotTrack-instelling van browsers. Coronamelder.nl houdt zich aan de in Nederland geldende wetgeving.

--- a/js/faq-tabbable.js
+++ b/js/faq-tabbable.js
@@ -44,7 +44,7 @@
             tab.setAttribute('aria-current', 'true');
 
             window.addEventListener('load', function() {
-                initFeedbackBtns();
+                // Piwik deactivated initFeedbackBtns();
             });
         }
 

--- a/js/statements.js
+++ b/js/statements.js
@@ -34,7 +34,7 @@
             trapFocus(dialog);
         }, 200);
 
-        _paq.push(['trackEvent', 'statement', document.documentElement.lang + ' - open', statementToOpen.querySelector('.statement__content h2').textContent]);
+        // _paq.push(['trackEvent', 'statement', document.documentElement.lang + ' - open', statementToOpen.querySelector('.statement__content h2').textContent]);
     }
 
     function closeStatement() {


### PR DESCRIPTION
Please note: this update has been requested by minvws with priority.
You can still review, if you wish, in this PR.

Piwik.JS is uitgezet, wordt niet meer gebruikt op de website.
Bij veelgestelde vragen: wel / niet beantwoord knoppen weggehaald (die werkten m.b.v. Piwik.JS)
Hierdoor meten we geen statistiek en feedback om content-, functie- en design overwegingen op te baseren
Cookies-pagina geüpdatet met nieuwe content
