### PR TITLE
Improve wording in 1-ready.md

### DIFF
--- a/_statements/nl/1-ready.md
+++ b/_statements/nl/1-ready.md
@@ -2,8 +2,8 @@
 index: 1
 title: Wanneer is de app klaar?
 icon: calendar
-summary: Op 1 september is het voornemen om de app landelijk te lanceren.
+summary: Het voornemen is om op 1 september de app landelijk te lanceren.
 lang: nl
 ---
 
-Op 1 september is het voornemen om de app landelijk te lanceren. Tot dat moment testen we de veiligheid en toegankelijkheid van de app. Met de testresultaten verbeteren we de app steeds verder.
+Het voornemen is om op 1 september de app landelijk te lanceren. Tot dat moment testen we de veiligheid en toegankelijkheid van de app. Met de testresultaten verbeteren we de app steeds verder.


### PR DESCRIPTION
Ik denk dat 'Op 1 september is het voornemen om [...]' beter kan zijn 'Het voornemen is om op 1 september [...]'. Anders lijkt het of er staat dat het voornemen pas op 1 september ontstaat.