### PR TITLE
Add focus visible license

### DIFF
--- a/vendor-licenses/LICENSE-focus-visible-polyfill.md
+++ b/vendor-licenses/LICENSE-focus-visible-polyfill.md
@@ -1,0 +1,5 @@
+All Reports in this Repository are licensed by Contributors under the 
+[W3C Software and Document
+License](http://www.w3.org/Consortium/Legal/2015/copyright-software-and-document). Contributions to
+Specifications are made under the [W3C CLA](https://www.w3.org/community/about/agreements/cla/).
+


### PR DESCRIPTION
Omdat we voor andere vendors ook de license hebben toegevoegd, hierbij ook voor de `focus-visible` polyfill. De daadwerkelijke license staat op de gelinkte pagina, deze heb ik niet woordelijk overgenomen.