### PR TITLE
Increase link size (fixes #191)

### DIFF
--- a/_includes/faq.scss
+++ b/_includes/faq.scss
@@ -131,13 +131,16 @@
     }
 }
 
-.faq__link:before {
-    content: '';
-    position: relative;
-    height: 10px;
-    width: 10px;
-    background: url(../img/chevron-right-darkblue.svg) no-repeat 50% 50%;
-    transition: var(--transition-out);
-    padding: 10px;
-}
+.faq__link {
+    font-size: 21px;
 
+    &:before {
+        content: '';
+        position: relative;
+        height: 10px;
+        width: 10px;
+        background: url(../img/chevron-right-darkblue.svg) no-repeat 50% 50%;
+        transition: var(--transition-out);
+        padding: 10px;
+    }
+}


### PR DESCRIPTION
This increases the size of the link to FAQ.

Before:

<img width="1091" alt="small faq link" src="https://user-images.githubusercontent.com/178782/90315083-cecd6d80-df18-11ea-99ea-51a8db55dc54.png">


After: 

<img width="1086" alt="slightly larger faq link, now same size as other links above" src="https://user-images.githubusercontent.com/178782/90315079-bfe6bb00-df18-11ea-8764-5f1c771a70cf.png">
