### PR TITLE
Update colofon-text.md: link to raw file with names instead of github page

### DIFF
--- a/_includes/colofon-text.md
+++ b/_includes/colofon-text.md
@@ -20,7 +20,7 @@ opsporen van eventuele kwetsbaarheden.
 
 - Naast de auteurs van de diverse open source, 3rd party bibliotheken hebben we
   bijdragen ontvangen van heel veel andere
-  [mensen](https://github.com/minvws/nl-covid19-notification-app-design/blob/master/%E2%9D%A4%EF%B8%8F)
+  [mensen](https://raw.githubusercontent.com/minvws/nl-covid19-notification-app-design/master/%E2%9D%A4%EF%B8%8F)
 
 ## Licenties, Condities en Disclaimers applicatie
 


### PR DESCRIPTION
link to the raw file with names of people who contributed, so as to avoid people having to scroll though git and github explanations and tutorials first before seeing the names