### PR TITLE
Add EN Colophon text

### DIFF
--- a/_includes/colofon-text-en.md
+++ b/_includes/colofon-text-en.md
@@ -1,0 +1,47 @@
+# Colophon
+
+The CoronaMelder app has been developed by the Ministry of Public Health,
+Welfare and Sport in collaboration with the RIVM and the national GGD
+institutions. The app could not have been realised without the help of dozens of
+experts, experience experts and a large civilian open-source community, who has
+monitored the process and tested the app as it was being developed. Everything
+has been done to create a safe, accessible and user-friendly app that ensures
+your privacy. And that helps to get — and keep — the coronavirus under control.
+
+## Source code
+
+The app's source code and its backend systems are all publicly available. You
+can find all code on [GitHub](https://github.com/minvws). This way, the precise
+way the app works is verifiable and controllable by many people, who can also
+help discover any potential vulnerabilities.
+
+## Contributions
+
+- Aside from the authors of the various open source, 3rd-party libraries, we
+  have received contributions from
+  [many others](https://github.com/minvws/nl-covid19-notification-app-design/blob/master/%E2%9D%A4%EF%B8%8F).
+
+## Application Licences, Terms & Conditions and Disclaimers
+
+- CoronaMelder
+  [iOS Application's open source licence](https://github.com/minvws/nl-covid19-notification-app-ios/blob/master/LICENSES.md)
+  and the Open Source
+  [iOS 3rd-party](https://github.com/minvws/nl-covid19-notification-app-ios/tree/master/licenses)
+  libraries used in the application.
+- CoronaMelder on
+  [Android's open source licence](https://github.com/minvws/nl-covid19-notification-app-android/blob/master/LICENSES.md).
+
+These licences, terms & conditions and disclaimers are an integral part of both
+the iOS and Android distribution and the Mobile Application.
+
+## Server Licences, Terms & Conditions and Disclaimers
+
+- [Backend licence](https://github.com/minvws/nl-covid19-notification-app-backend/blob/master/LICENSES.md)
+  and the
+  [3rd-party](https://github.com/minvws/nl-covid19-notification-app-backend/tree/master/LICENSE)
+  backend libraries.
+
+## Reporting vulnerabilities
+
+Any vulnerabilities can be confidentially (or anonymously) reported to the
+[National Cyber Security Center of the Dutch Government](https://www.ncsc.nl/contact/kwetsbaarheid-melden).

--- a/_includes/colofon-text.md
+++ b/_includes/colofon-text.md
@@ -1,6 +1,5 @@
 # Colofon
 
-{: .md-block-lead }
 De CoronaMelder-app is ontwikkeld door het Ministerie van Volksgezondheid,
 Welzijn en Sport in samenwerking met het RIVM en de landelijke GGD’en. De app
 had niet tot stand kunnen komen zonder de hulp van tientallen experts,

--- a/ar/colofon-in-app.md
+++ b/ar/colofon-in-app.md
@@ -4,4 +4,4 @@ lang: en
 title: Colofon
 ---
 
-{% include colofon-text.md %}
+{% include colofon-text-en.md %}

--- a/ar/colofon.md
+++ b/ar/colofon.md
@@ -5,4 +5,4 @@ showHomeBtn: true
 title: Colofon
 ---
 
-{% include colofon-text.md %}
+{% include colofon-text-en.md %}

--- a/bg/colofon-in-app.md
+++ b/bg/colofon-in-app.md
@@ -4,4 +4,4 @@ lang: en
 title: Colofon
 ---
 
-{% include colofon-text.md %}
+{% include colofon-text-en.md %}

--- a/bg/colofon.md
+++ b/bg/colofon.md
@@ -5,4 +5,4 @@ showHomeBtn: true
 title: Colofon
 ---
 
-{% include colofon-text.md %}
+{% include colofon-text-en.md %}

--- a/de/colofon-in-app.md
+++ b/de/colofon-in-app.md
@@ -4,4 +4,4 @@ lang: en
 title: Colofon
 ---
 
-{% include colofon-text.md %}
+{% include colofon-text-en.md %}

--- a/de/colofon.md
+++ b/de/colofon.md
@@ -5,4 +5,4 @@ showHomeBtn: true
 title: Colofon
 ---
 
-{% include colofon-text.md %}
+{% include colofon-text-en.md %}

--- a/en/colofon-in-app.md
+++ b/en/colofon-in-app.md
@@ -4,4 +4,4 @@ lang: en
 title: Colofon
 ---
 
-{% include colofon-text.md %}
+{% include colofon-text-en.md %}

--- a/en/colofon.md
+++ b/en/colofon.md
@@ -5,4 +5,4 @@ showHomeBtn: true
 title: Colofon
 ---
 
-{% include colofon-text.md %}
+{% include colofon-text-en.md %}

--- a/es/colofon-in-app.md
+++ b/es/colofon-in-app.md
@@ -4,4 +4,4 @@ lang: en
 title: Colofon
 ---
 
-{% include colofon-text.md %}
+{% include colofon-text-en.md %}

--- a/es/colofon.md
+++ b/es/colofon.md
@@ -5,4 +5,4 @@ showHomeBtn: true
 title: Colofon
 ---
 
-{% include colofon-text.md %}
+{% include colofon-text-en.md %}

--- a/fr/colofon-in-app.md
+++ b/fr/colofon-in-app.md
@@ -4,4 +4,4 @@ lang: en
 title: Colofon
 ---
 
-{% include colofon-text.md %}
+{% include colofon-text-en.md %}

--- a/fr/colofon.md
+++ b/fr/colofon.md
@@ -5,4 +5,4 @@ showHomeBtn: true
 title: Colofon
 ---
 
-{% include colofon-text.md %}
+{% include colofon-text-en.md %}

--- a/pl/colofon-in-app.md
+++ b/pl/colofon-in-app.md
@@ -4,4 +4,4 @@ lang: en
 title: Colofon
 ---
 
-{% include colofon-text.md %}
+{% include colofon-text-en.md %}

--- a/pl/colofon.md
+++ b/pl/colofon.md
@@ -5,4 +5,4 @@ showHomeBtn: true
 title: Colofon
 ---
 
-{% include colofon-text.md %}
+{% include colofon-text-en.md %}

--- a/ro/colofon-in-app.md
+++ b/ro/colofon-in-app.md
@@ -4,4 +4,4 @@ lang: en
 title: Colofon
 ---
 
-{% include colofon-text.md %}
+{% include colofon-text-en.md %}

--- a/ro/colofon.md
+++ b/ro/colofon.md
@@ -5,4 +5,4 @@ showHomeBtn: true
 title: Colofon
 ---
 
-{% include colofon-text.md %}
+{% include colofon-text-en.md %}

--- a/tr/colofon-in-app.md
+++ b/tr/colofon-in-app.md
@@ -4,4 +4,4 @@ lang: en
 title: Colofon
 ---
 
-{% include colofon-text.md %}
+{% include colofon-text-en.md %}

--- a/tr/colofon.md
+++ b/tr/colofon.md
@@ -5,4 +5,4 @@ showHomeBtn: true
 title: Colofon
 ---
 
-{% include colofon-text.md %}
+{% include colofon-text-en.md %}


### PR DESCRIPTION
Add EN Colophon text and use it in all non-Dutch translations.

Remove the big intro styling from the Dutch colofon text.