### PR TITLE
Restyle the current language indicator

### DIFF
--- a/_includes/language-picker.html
+++ b/_includes/language-picker.html
@@ -28,21 +28,21 @@
            {%- else -%}
             {%- assign lang_prefix = lang[0] -%}
             {%- assign slug = '/' %}
-          {%- endif -%}
-        
+          {% endif %}
+
           <a class="language-picker__link"
             href="/{{ lang_prefix }}{{ slug }}"
             hreflang="{{ lang[0] }}"
             lang="{{ lang[0] }}"
           >
-          {%- endif -%}
-          {{- language.label -}}
-          {%- if lang[0] == page.lang -%}
-          <span class="screen-reader-text">({{ site.data.translations.header-language-picker-current-lang[page.lang] }})</span>
-          {%- endif -%}
-          {%- if lang[0] != page.lang -%}
+          {% endif %}
+          {{ language.label }}
+          {% if lang[0] == page.lang %}
+            ({{ site.data.translations.header-language-picker-current-lang[page.lang] }})
+          {% endif %}
+          {% if lang[0] != page.lang %}
           </a>
-          {%- endif -%}
+          {% endif %}
         </li>
       {% endfor %}
     </ul>

--- a/css/_language-picker.scss
+++ b/css/_language-picker.scss
@@ -75,9 +75,9 @@
 }
 
 .language-picker__title {
-    color: #090C0E;
-    font-weight: 400;
-    font-size: 100%;
+    color: #090c0e;
+    font-size: 16px;
+    font-weight: normal;
     line-height: 1;
     margin: 0;
     padding: 13px 18px;
@@ -86,18 +86,19 @@
 }
 
 .language-picker__languages {
-    margin: 0;
     list-style: none;
 }
 
 .language-picker__language {
-    color: #999999;
+    color: #333;
+    font-weight: bold;
     margin: 0;
     padding: 6px 18px;
 }
 
 .language-picker__link {
     display: block;
+    font-weight: normal;
     margin: -6px -18px;
     padding: 6px 18px;
     color: $color-RO_donkerblauw;


### PR DESCRIPTION
Make the current language black and show the current language label
instead of only showing it for screen readers.

<img width="400" alt="image" src="https://user-images.githubusercontent.com/406439/90344267-6bc30000-e018-11ea-87e8-4ef98817704c.png">
