### PR TITLE
Fixes circles header (added overflow hidden: ) & open classlang picker

### DIFF
--- a/css/_language-picker.scss
+++ b/css/_language-picker.scss
@@ -10,9 +10,15 @@
     &:hover {
         background-color: rgba($color-RO_donkerblauw--interaction, 1);
         color: #fff;
-        transition: background-color var(--transition-in), color var(--transition-in);
+        transition: color var(--transition-in), color var(--transition-in), top var(--transition-in);
+    }
+
+    &.open {
+        top: 10px;
     }
 }
+
+
 
 .content-error .language-picker {
     top: -26px;

--- a/css/header-yellow.scss
+++ b/css/header-yellow.scss
@@ -12,6 +12,7 @@
 
     @media(min-width: 960px) {
         background-image: none;
+        overflow: hidden;
 
         &::before {
             bottom: 0;

--- a/js/language-picker.js
+++ b/js/language-picker.js
@@ -13,12 +13,14 @@
 		button.setAttribute('aria-expanded', ariaExpanded);
 
 		if (ariaExpanded) {
+			languagePicker.classList.add("open");
 			document.documentElement
 				.addEventListener('keydown', escapeKeydownHandler, true);
 			document.documentElement
 				.addEventListener('click', outsideClickHandler, true);
 			firstInteractive.focus();
 		} else {
+			languagePicker.classList.remove("open");
 			document.documentElement
 				.removeEventListener('keydown', escapeKeydownHandler, true);
 			document.documentElement


### PR DESCRIPTION
Voor de taal selectie is eerder overflow hidden weggehaald. Maar dan steken de circles uit. Niet zoals het design
Daarom een pen class toggle toevoegd aan de lang picker.
![circles](https://user-images.githubusercontent.com/4374953/90345773-d75e9a80-e023-11ea-8203-47d8c97d6da1.jpg)
