### PR TITLE
ontbrekend woord in accessibility-in-app.md

### DIFF
--- a/nl/accessibility-in-app.md
+++ b/nl/accessibility-in-app.md
@@ -15,6 +15,6 @@ De CoronaMelder-app volgt de Web Content Accessibility Guidelines (WCAG) 2.1 op 
 ## Hoe we zorgen voor een toegankelijke CoronaMelder?
 
 - In het team dat de app bouwt zijn mensen opgenomen die veel ervaring hebben met digitale toegankelijkheid
-- In het ontwerp van de app is rekening gehouden met toegankelijkheid. Zo is waar een tekstalternatief voor afbeeldingen gebruikt en is er gelet op het gebruik van kleur en kleurcontrast
+- In het ontwerp van de app is rekening gehouden met toegankelijkheid. Zo is waar mogelijk een tekstalternatief voor afbeeldingen gebruikt en is er gelet op het gebruik van kleur en kleurcontrast
 - Er zijn veel gebruikerstests gedaan, ook met mensen die een functiebeperking hebben. De resultaten hiervan zijn verwerkt in de app
 - De toegankelijkheid van de app is zowel door het team als een onafhankelijke partij getest


### PR DESCRIPTION
"Zo is waar een tekstalternatief voor afbeeldingen gebruikt": hier ontbreekt een woord als "mogelijk".