### PR TITLE
Adds header to footer section

### DIFF
--- a/_data/translations.yml
+++ b/_data/translations.yml
@@ -300,6 +300,9 @@ footer-phone-opening-hours-weekend:
   nl: Zaterdag en zondag 10.00 – 16.00 uur 
   en: Saturday and Sunday 10.00 a.m. – 04.00 p.m
 
+footer-colophon: 
+  nl: Colofon
+  en: Colophon
 footer-logos-info_md:
   nl: De corona-app wordt ontwikkeld in opdracht van Het ministerie van Volksgezondheid, Welzijn en Sport. Dat gebeurt in samenwerking met het <a href="https://www.rivm.nl/" target="_blank" noreferrer><abbr title="Rijksinstituut voor Volksgezondheid en Milieu">RIVM</abbr></a> en de <a href="https://www.ggd.nl/" target="_blank"><abbr title="Gemeentelijke gezondheidsdienst">GGD</abbr></a>.
   en: The CoronaMelder app is being developed on behalf of the Ministry of Health, Welfare and Sport. This is being done in collaboration with the <a href="https://www.rivm.nl/" target="_blank" noreferrer><abbr title="Rijksinstituut voor Volksgezondheid en Milieu">RIVM</abbr></a> and the <a href="https://www.ggd.nl/" target="_blank"><abbr title="Gemeentelijke gezondheidsdienst">GGD</abbr></a>.

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -15,7 +15,9 @@
         <div class="footer-inner">
             <div class="footer-links">
                 <div class="footer-links-col ___desktop-50">
-                    <div class="footer-logos-info">{{ site.data.translations.footer-logos-info_md[page.lang] | markdownify }}</div>
+                    <div class="footer-logos-info">
+                        <h2 class="screen-reader-text">{{ site.data.translations.footer-colophon[page.lang] | markdownify }}</h2>
+                        {{ site.data.translations.footer-logos-info_md[page.lang] | markdownify }}</div>
                 </div>
                 <div class="footer-links-col ___desktop-25">
                     <h3>{{ site.data.translations.footer-misc-title[page.lang] }}</h3>


### PR DESCRIPTION
I think this could solve issue #260 ! There was no header for the footer, which has only h3 level titles, which make them fall under the last h2 seen in the page content. With this PR there _is_ a (screen reader only) header.
(What I didn't solve was the h3 language switch, I want to know first if there is a reason for it)

<img width="351" alt="Schermafbeelding 2020-08-23 om 10 12 01" src="https://user-images.githubusercontent.com/7202272/90974264-c503c580-e529-11ea-964a-d6e1cc9cd22a.png">
