### PR TITLE
Mailto Usability Improvement

### DIFF
--- a/_data/translations.yml
+++ b/_data/translations.yml
@@ -390,3 +390,7 @@ error-back-to-faq:
   nl: Ga naar veelgestelde vragen
   en: Go to frequently asked questions
   
+accessibility-in-app-email-subject:
+  nl: Probleem bij het gebruik van de app
+  en: Issue Using the App
+  

--- a/ar/accessibility-in-app.md
+++ b/ar/accessibility-in-app.md
@@ -7,7 +7,7 @@ title: Accessibility
 # Accessibility
 
 <p class="md-block-lead md-text-color-RO-donkerblauw" markdown="1">
-  The CoronaMelder app should be accessible to everyone. From its very first design accessibility has been taken into account, with the help of experts and experience experts. Yet the app might not be as accessible to you. Are you unable to use the app well? Let us know by emailing <a href="mailto:coronamelder@minvws.nl">coronamelder@minvws.nl</a>.
+  The CoronaMelder app should be accessible to everyone. From its very first design accessibility has been taken into account, with the help of experts and experience experts. Yet the app might not be as accessible to you. Are you unable to use the app well? Let us know by emailing <a href="mailto:coronamelder@minvws.nl?subject={{ site.data.translations.accessibility-in-app-email-subject[page.lang] }}">coronamelder@minvws.nl</a>.
 </p>
 
 The CoronaMelder app follows the [Web Content Accessibility Guidelines (WCAG) 2.1](https://www.w3.org/TR/2018/REC-WCAG21-20180605/) on level AA as set out in the European standard EN 301 549. If this European standard is updated with specific guidelines for mobile applications, we will follow them.

--- a/ar/accessibility-in-app.md
+++ b/ar/accessibility-in-app.md
@@ -7,7 +7,7 @@ title: Accessibility
 # Accessibility
 
 <p class="md-block-lead md-text-color-RO-donkerblauw" markdown="1">
-  The CoronaMelder app should be accessible to everyone. From its very first design accessibility has been taken into account, with the help of experts and experience experts. Yet the app might not be as accessible to you. Are you unable to use the app well? Let us know by emailing <a href="mailto:coronamelder@minvws.nl?subject={{ site.data.translations.accessibility-in-app-email-subject[page.lang] }}">coronamelder@minvws.nl</a>.
+  The CoronaMelder app should be accessible to everyone. From its very first design accessibility has been taken into account, with the help of experts and experience experts. Yet the app might not be as accessible to you. Are you unable to use the app well? Let us know by emailing <a href="mailto:coronamelder@minvws.nl?subject={{ site.data.translations.accessibility-in-app-email-subject[page.lang] }}" target="_blank">.
 </p>
 
 The CoronaMelder app follows the [Web Content Accessibility Guidelines (WCAG) 2.1](https://www.w3.org/TR/2018/REC-WCAG21-20180605/) on level AA as set out in the European standard EN 301 549. If this European standard is updated with specific guidelines for mobile applications, we will follow them.

--- a/bg/accessibility-in-app.md
+++ b/bg/accessibility-in-app.md
@@ -7,7 +7,7 @@ title: Accessibility
 # Accessibility
 
 <p class="md-block-lead md-text-color-RO-donkerblauw" markdown="1">
-  The CoronaMelder app should be accessible to everyone. From its very first design accessibility has been taken into account, with the help of experts and experience experts. Yet the app might not be as accessible to you. Are you unable to use the app well? Let us know by emailing <a href="mailto:coronamelder@minvws.nl">coronamelder@minvws.nl</a>.
+  The CoronaMelder app should be accessible to everyone. From its very first design accessibility has been taken into account, with the help of experts and experience experts. Yet the app might not be as accessible to you. Are you unable to use the app well? Let us know by emailing <a href="mailto:coronamelder@minvws.nl?subject={{ site.data.translations.accessibility-in-app-email-subject[page.lang] }}">coronamelder@minvws.nl</a>.
 </p>
 
 The CoronaMelder app follows the [Web Content Accessibility Guidelines (WCAG) 2.1](https://www.w3.org/TR/2018/REC-WCAG21-20180605/) on level AA as set out in the European standard EN 301 549. If this European standard is updated with specific guidelines for mobile applications, we will follow them.

--- a/bg/accessibility-in-app.md
+++ b/bg/accessibility-in-app.md
@@ -7,7 +7,7 @@ title: Accessibility
 # Accessibility
 
 <p class="md-block-lead md-text-color-RO-donkerblauw" markdown="1">
-  The CoronaMelder app should be accessible to everyone. From its very first design accessibility has been taken into account, with the help of experts and experience experts. Yet the app might not be as accessible to you. Are you unable to use the app well? Let us know by emailing <a href="mailto:coronamelder@minvws.nl?subject={{ site.data.translations.accessibility-in-app-email-subject[page.lang] }}">coronamelder@minvws.nl</a>.
+  The CoronaMelder app should be accessible to everyone. From its very first design accessibility has been taken into account, with the help of experts and experience experts. Yet the app might not be as accessible to you. Are you unable to use the app well? Let us know by emailing <a href="mailto:coronamelder@minvws.nl?subject={{ site.data.translations.accessibility-in-app-email-subject[page.lang] }}" target="_blank">.
 </p>
 
 The CoronaMelder app follows the [Web Content Accessibility Guidelines (WCAG) 2.1](https://www.w3.org/TR/2018/REC-WCAG21-20180605/) on level AA as set out in the European standard EN 301 549. If this European standard is updated with specific guidelines for mobile applications, we will follow them.

--- a/de/accessibility-in-app.md
+++ b/de/accessibility-in-app.md
@@ -7,7 +7,7 @@ title: Accessibility
 # Accessibility
 
 <p class="md-block-lead md-text-color-RO-donkerblauw" markdown="1">
-  The CoronaMelder app should be accessible to everyone. From its very first design accessibility has been taken into account, with the help of experts and experience experts. Yet the app might not be as accessible to you. Are you unable to use the app well? Let us know by emailing <a href="mailto:coronamelder@minvws.nl">coronamelder@minvws.nl</a>.
+  The CoronaMelder app should be accessible to everyone. From its very first design accessibility has been taken into account, with the help of experts and experience experts. Yet the app might not be as accessible to you. Are you unable to use the app well? Let us know by emailing <a href="mailto:coronamelder@minvws.nl?subject={{ site.data.translations.accessibility-in-app-email-subject[page.lang] }}">coronamelder@minvws.nl</a>.
 </p>
 
 The CoronaMelder app follows the [Web Content Accessibility Guidelines (WCAG) 2.1](https://www.w3.org/TR/2018/REC-WCAG21-20180605/) on level AA as set out in the European standard EN 301 549. If this European standard is updated with specific guidelines for mobile applications, we will follow them.

--- a/de/accessibility-in-app.md
+++ b/de/accessibility-in-app.md
@@ -7,7 +7,7 @@ title: Accessibility
 # Accessibility
 
 <p class="md-block-lead md-text-color-RO-donkerblauw" markdown="1">
-  The CoronaMelder app should be accessible to everyone. From its very first design accessibility has been taken into account, with the help of experts and experience experts. Yet the app might not be as accessible to you. Are you unable to use the app well? Let us know by emailing <a href="mailto:coronamelder@minvws.nl?subject={{ site.data.translations.accessibility-in-app-email-subject[page.lang] }}">coronamelder@minvws.nl</a>.
+  The CoronaMelder app should be accessible to everyone. From its very first design accessibility has been taken into account, with the help of experts and experience experts. Yet the app might not be as accessible to you. Are you unable to use the app well? Let us know by emailing <a href="mailto:coronamelder@minvws.nl?subject={{ site.data.translations.accessibility-in-app-email-subject[page.lang] }}" target="_blank">.
 </p>
 
 The CoronaMelder app follows the [Web Content Accessibility Guidelines (WCAG) 2.1](https://www.w3.org/TR/2018/REC-WCAG21-20180605/) on level AA as set out in the European standard EN 301 549. If this European standard is updated with specific guidelines for mobile applications, we will follow them.

--- a/en/accessibility-in-app.md
+++ b/en/accessibility-in-app.md
@@ -7,7 +7,7 @@ title: Accessibility
 # Accessibility
 
 <p class="md-block-lead md-text-color-RO-donkerblauw" markdown="1">
-  The CoronaMelder app should be accessible to everyone. From its very first design accessibility has been taken into account, with the help of experts and experience experts. Yet the app might not be as accessible to you. Are you unable to use the app well? Let us know by emailing <a href="mailto:coronamelder@minvws.nl">coronamelder@minvws.nl</a>.
+  The CoronaMelder app should be accessible to everyone. From its very first design accessibility has been taken into account, with the help of experts and experience experts. Yet the app might not be as accessible to you. Are you unable to use the app well? Let us know by emailing <a href="mailto:coronamelder@minvws.nl?subject={{ site.data.translations.accessibility-in-app-email-subject[page.lang] }}">coronamelder@minvws.nl</a>.
 </p>
 
 The CoronaMelder app follows the [Web Content Accessibility Guidelines (WCAG) 2.1](https://www.w3.org/TR/2018/REC-WCAG21-20180605/) on level AA as set out in the European standard EN 301 549. If this European standard is updated with specific guidelines for mobile applications, we will follow them.

--- a/en/accessibility-in-app.md
+++ b/en/accessibility-in-app.md
@@ -7,7 +7,7 @@ title: Accessibility
 # Accessibility
 
 <p class="md-block-lead md-text-color-RO-donkerblauw" markdown="1">
-  The CoronaMelder app should be accessible to everyone. From its very first design accessibility has been taken into account, with the help of experts and experience experts. Yet the app might not be as accessible to you. Are you unable to use the app well? Let us know by emailing <a href="mailto:coronamelder@minvws.nl?subject={{ site.data.translations.accessibility-in-app-email-subject[page.lang] }}">coronamelder@minvws.nl</a>.
+  The CoronaMelder app should be accessible to everyone. From its very first design accessibility has been taken into account, with the help of experts and experience experts. Yet the app might not be as accessible to you. Are you unable to use the app well? Let us know by emailing <a href="mailto:coronamelder@minvws.nl?subject={{ site.data.translations.accessibility-in-app-email-subject[page.lang] }}" target="_blank">coronamelder@minvws.nl</a>.
 </p>
 
 The CoronaMelder app follows the [Web Content Accessibility Guidelines (WCAG) 2.1](https://www.w3.org/TR/2018/REC-WCAG21-20180605/) on level AA as set out in the European standard EN 301 549. If this European standard is updated with specific guidelines for mobile applications, we will follow them.

--- a/es/accessibility-in-app.md
+++ b/es/accessibility-in-app.md
@@ -7,7 +7,7 @@ title: Accessibility
 # Accessibility
 
 <p class="md-block-lead md-text-color-RO-donkerblauw" markdown="1">
-  The CoronaMelder app should be accessible to everyone. From its very first design accessibility has been taken into account, with the help of experts and experience experts. Yet the app might not be as accessible to you. Are you unable to use the app well? Let us know by emailing <a href="mailto:coronamelder@minvws.nl">coronamelder@minvws.nl</a>.
+  The CoronaMelder app should be accessible to everyone. From its very first design accessibility has been taken into account, with the help of experts and experience experts. Yet the app might not be as accessible to you. Are you unable to use the app well? Let us know by emailing <a href="mailto:coronamelder@minvws.nl?subject={{ site.data.translations.accessibility-in-app-email-subject[page.lang] }}">coronamelder@minvws.nl</a>.
 </p>
 
 The CoronaMelder app follows the [Web Content Accessibility Guidelines (WCAG) 2.1](https://www.w3.org/TR/2018/REC-WCAG21-20180605/) on level AA as set out in the European standard EN 301 549. If this European standard is updated with specific guidelines for mobile applications, we will follow them.

--- a/es/accessibility-in-app.md
+++ b/es/accessibility-in-app.md
@@ -7,7 +7,7 @@ title: Accessibility
 # Accessibility
 
 <p class="md-block-lead md-text-color-RO-donkerblauw" markdown="1">
-  The CoronaMelder app should be accessible to everyone. From its very first design accessibility has been taken into account, with the help of experts and experience experts. Yet the app might not be as accessible to you. Are you unable to use the app well? Let us know by emailing <a href="mailto:coronamelder@minvws.nl?subject={{ site.data.translations.accessibility-in-app-email-subject[page.lang] }}">coronamelder@minvws.nl</a>.
+  The CoronaMelder app should be accessible to everyone. From its very first design accessibility has been taken into account, with the help of experts and experience experts. Yet the app might not be as accessible to you. Are you unable to use the app well? Let us know by emailing <a href="mailto:coronamelder@minvws.nl?subject={{ site.data.translations.accessibility-in-app-email-subject[page.lang] }}" target="_blank">.
 </p>
 
 The CoronaMelder app follows the [Web Content Accessibility Guidelines (WCAG) 2.1](https://www.w3.org/TR/2018/REC-WCAG21-20180605/) on level AA as set out in the European standard EN 301 549. If this European standard is updated with specific guidelines for mobile applications, we will follow them.

--- a/fr/accessibility-in-app.md
+++ b/fr/accessibility-in-app.md
@@ -7,7 +7,7 @@ title: Accessibility
 # Accessibility
 
 <p class="md-block-lead md-text-color-RO-donkerblauw" markdown="1">
-  The CoronaMelder app should be accessible to everyone. From its very first design accessibility has been taken into account, with the help of experts and experience experts. Yet the app might not be as accessible to you. Are you unable to use the app well? Let us know by emailing <a href="mailto:coronamelder@minvws.nl">coronamelder@minvws.nl</a>.
+  The CoronaMelder app should be accessible to everyone. From its very first design accessibility has been taken into account, with the help of experts and experience experts. Yet the app might not be as accessible to you. Are you unable to use the app well? Let us know by emailing <a href="mailto:coronamelder@minvws.nl?subject={{ site.data.translations.accessibility-in-app-email-subject[page.lang] }}">coronamelder@minvws.nl</a>.
 </p>
 
 The CoronaMelder app follows the [Web Content Accessibility Guidelines (WCAG) 2.1](https://www.w3.org/TR/2018/REC-WCAG21-20180605/) on level AA as set out in the European standard EN 301 549. If this European standard is updated with specific guidelines for mobile applications, we will follow them.

--- a/fr/accessibility-in-app.md
+++ b/fr/accessibility-in-app.md
@@ -7,7 +7,7 @@ title: Accessibility
 # Accessibility
 
 <p class="md-block-lead md-text-color-RO-donkerblauw" markdown="1">
-  The CoronaMelder app should be accessible to everyone. From its very first design accessibility has been taken into account, with the help of experts and experience experts. Yet the app might not be as accessible to you. Are you unable to use the app well? Let us know by emailing <a href="mailto:coronamelder@minvws.nl?subject={{ site.data.translations.accessibility-in-app-email-subject[page.lang] }}">coronamelder@minvws.nl</a>.
+  The CoronaMelder app should be accessible to everyone. From its very first design accessibility has been taken into account, with the help of experts and experience experts. Yet the app might not be as accessible to you. Are you unable to use the app well? Let us know by emailing <a href="mailto:coronamelder@minvws.nl?subject={{ site.data.translations.accessibility-in-app-email-subject[page.lang] }}" target="_blank">.
 </p>
 
 The CoronaMelder app follows the [Web Content Accessibility Guidelines (WCAG) 2.1](https://www.w3.org/TR/2018/REC-WCAG21-20180605/) on level AA as set out in the European standard EN 301 549. If this European standard is updated with specific guidelines for mobile applications, we will follow them.

--- a/nl/accessibility-in-app.md
+++ b/nl/accessibility-in-app.md
@@ -7,7 +7,7 @@ title: Toegankelijkheid
 # Toegankelijkheid
 
 <p class="md-block-lead md-text-color-RO-donkerblauw" markdown="1">
-  De CoronaMelder-app moet toegankelijk zijn voor iedereen. Vanaf het eerste ontwerp is daar met behulp van experts en ervaringsdeskundigen rekening mee gehouden. Toch kan het zo zijn dat de app misschien niet goed toegankelijk is. Kun je de app niet goed gebruiken? Meld dat dan via <a href="mailto:coronamelder@minvws.nl?subject={{ site.data.translations.accessibility-in-app-email-subject[page.lang] }}">coronamelder@minvws.nl</a>.
+  De CoronaMelder-app moet toegankelijk zijn voor iedereen. Vanaf het eerste ontwerp is daar met behulp van experts en ervaringsdeskundigen rekening mee gehouden. Toch kan het zo zijn dat de app misschien niet goed toegankelijk is. Kun je de app niet goed gebruiken? Meld dat dan via <a href="mailto:coronamelder@minvws.nl?subject={{ site.data.translations.accessibility-in-app-email-subject[page.lang] }}" target="_blank">.
 </p>
 
 De CoronaMelder-app volgt de Web Content Accessibility Guidelines (WCAG) 2.1 op niveau AA zoals opgenomen in Europese standaard EN 301 549. Als deze Europese standaard wordt bijgewerkt met specifieke richtlijnen voor mobiele applicaties, zullen we deze volgen.

--- a/nl/accessibility-in-app.md
+++ b/nl/accessibility-in-app.md
@@ -7,7 +7,7 @@ title: Toegankelijkheid
 # Toegankelijkheid
 
 <p class="md-block-lead md-text-color-RO-donkerblauw" markdown="1">
-  De CoronaMelder-app moet toegankelijk zijn voor iedereen. Vanaf het eerste ontwerp is daar met behulp van experts en ervaringsdeskundigen rekening mee gehouden. Toch kan het zo zijn dat de app misschien niet goed toegankelijk is. Kun je de app niet goed gebruiken? Meld dat dan via <a href="mailto:coronamelder@minvws.nl">coronamelder@minvws.nl</a>.
+  De CoronaMelder-app moet toegankelijk zijn voor iedereen. Vanaf het eerste ontwerp is daar met behulp van experts en ervaringsdeskundigen rekening mee gehouden. Toch kan het zo zijn dat de app misschien niet goed toegankelijk is. Kun je de app niet goed gebruiken? Meld dat dan via <a href="mailto:coronamelder@minvws.nl?subject={{ site.data.translations.accessibility-in-app-email-subject[page.lang] }}">coronamelder@minvws.nl</a>.
 </p>
 
 De CoronaMelder-app volgt de Web Content Accessibility Guidelines (WCAG) 2.1 op niveau AA zoals opgenomen in Europese standaard EN 301 549. Als deze Europese standaard wordt bijgewerkt met specifieke richtlijnen voor mobiele applicaties, zullen we deze volgen.

--- a/pl/accessibility-in-app.md
+++ b/pl/accessibility-in-app.md
@@ -7,7 +7,7 @@ title: Accessibility
 # Accessibility
 
 <p class="md-block-lead md-text-color-RO-donkerblauw" markdown="1">
-  The CoronaMelder app should be accessible to everyone. From its very first design accessibility has been taken into account, with the help of experts and experience experts. Yet the app might not be as accessible to you. Are you unable to use the app well? Let us know by emailing <a href="mailto:coronamelder@minvws.nl">coronamelder@minvws.nl</a>.
+  The CoronaMelder app should be accessible to everyone. From its very first design accessibility has been taken into account, with the help of experts and experience experts. Yet the app might not be as accessible to you. Are you unable to use the app well? Let us know by emailing <a href="mailto:coronamelder@minvws.nl?subject={{ site.data.translations.accessibility-in-app-email-subject[page.lang] }}">coronamelder@minvws.nl</a>.
 </p>
 
 The CoronaMelder app follows the [Web Content Accessibility Guidelines (WCAG) 2.1](https://www.w3.org/TR/2018/REC-WCAG21-20180605/) on level AA as set out in the European standard EN 301 549. If this European standard is updated with specific guidelines for mobile applications, we will follow them.

--- a/pl/accessibility-in-app.md
+++ b/pl/accessibility-in-app.md
@@ -7,7 +7,7 @@ title: Accessibility
 # Accessibility
 
 <p class="md-block-lead md-text-color-RO-donkerblauw" markdown="1">
-  The CoronaMelder app should be accessible to everyone. From its very first design accessibility has been taken into account, with the help of experts and experience experts. Yet the app might not be as accessible to you. Are you unable to use the app well? Let us know by emailing <a href="mailto:coronamelder@minvws.nl?subject={{ site.data.translations.accessibility-in-app-email-subject[page.lang] }}">coronamelder@minvws.nl</a>.
+  The CoronaMelder app should be accessible to everyone. From its very first design accessibility has been taken into account, with the help of experts and experience experts. Yet the app might not be as accessible to you. Are you unable to use the app well? Let us know by emailing <a href="mailto:coronamelder@minvws.nl?subject={{ site.data.translations.accessibility-in-app-email-subject[page.lang] }}" target="_blank">.
 </p>
 
 The CoronaMelder app follows the [Web Content Accessibility Guidelines (WCAG) 2.1](https://www.w3.org/TR/2018/REC-WCAG21-20180605/) on level AA as set out in the European standard EN 301 549. If this European standard is updated with specific guidelines for mobile applications, we will follow them.

--- a/ro/accessibility-in-app.md
+++ b/ro/accessibility-in-app.md
@@ -7,7 +7,7 @@ title: Accessibility
 # Accessibility
 
 <p class="md-block-lead md-text-color-RO-donkerblauw" markdown="1">
-  The CoronaMelder app should be accessible to everyone. From its very first design accessibility has been taken into account, with the help of experts and experience experts. Yet the app might not be as accessible to you. Are you unable to use the app well? Let us know by emailing <a href="mailto:coronamelder@minvws.nl">coronamelder@minvws.nl</a>.
+  The CoronaMelder app should be accessible to everyone. From its very first design accessibility has been taken into account, with the help of experts and experience experts. Yet the app might not be as accessible to you. Are you unable to use the app well? Let us know by emailing <a href="mailto:coronamelder@minvws.nl?subject={{ site.data.translations.accessibility-in-app-email-subject[page.lang] }}">coronamelder@minvws.nl</a>.
 </p>
 
 The CoronaMelder app follows the [Web Content Accessibility Guidelines (WCAG) 2.1](https://www.w3.org/TR/2018/REC-WCAG21-20180605/) on level AA as set out in the European standard EN 301 549. If this European standard is updated with specific guidelines for mobile applications, we will follow them.

--- a/ro/accessibility-in-app.md
+++ b/ro/accessibility-in-app.md
@@ -7,7 +7,7 @@ title: Accessibility
 # Accessibility
 
 <p class="md-block-lead md-text-color-RO-donkerblauw" markdown="1">
-  The CoronaMelder app should be accessible to everyone. From its very first design accessibility has been taken into account, with the help of experts and experience experts. Yet the app might not be as accessible to you. Are you unable to use the app well? Let us know by emailing <a href="mailto:coronamelder@minvws.nl?subject={{ site.data.translations.accessibility-in-app-email-subject[page.lang] }}">coronamelder@minvws.nl</a>.
+  The CoronaMelder app should be accessible to everyone. From its very first design accessibility has been taken into account, with the help of experts and experience experts. Yet the app might not be as accessible to you. Are you unable to use the app well? Let us know by emailing <a href="mailto:coronamelder@minvws.nl?subject={{ site.data.translations.accessibility-in-app-email-subject[page.lang] }}" target="_blank">.
 </p>
 
 The CoronaMelder app follows the [Web Content Accessibility Guidelines (WCAG) 2.1](https://www.w3.org/TR/2018/REC-WCAG21-20180605/) on level AA as set out in the European standard EN 301 549. If this European standard is updated with specific guidelines for mobile applications, we will follow them.

--- a/tr/accessibility-in-app.md
+++ b/tr/accessibility-in-app.md
@@ -7,7 +7,7 @@ title: Accessibility
 # Accessibility
 
 <p class="md-block-lead md-text-color-RO-donkerblauw" markdown="1">
-  The CoronaMelder app should be accessible to everyone. From its very first design accessibility has been taken into account, with the help of experts and experience experts. Yet the app might not be as accessible to you. Are you unable to use the app well? Let us know by emailing <a href="mailto:coronamelder@minvws.nl">coronamelder@minvws.nl</a>.
+  The CoronaMelder app should be accessible to everyone. From its very first design accessibility has been taken into account, with the help of experts and experience experts. Yet the app might not be as accessible to you. Are you unable to use the app well? Let us know by emailing <a href="mailto:coronamelder@minvws.nl?subject={{ site.data.translations.accessibility-in-app-email-subject[page.lang] }}">coronamelder@minvws.nl</a>.
 </p>
 
 The CoronaMelder app follows the [Web Content Accessibility Guidelines (WCAG) 2.1](https://www.w3.org/TR/2018/REC-WCAG21-20180605/) on level AA as set out in the European standard EN 301 549. If this European standard is updated with specific guidelines for mobile applications, we will follow them.

--- a/tr/accessibility-in-app.md
+++ b/tr/accessibility-in-app.md
@@ -7,7 +7,7 @@ title: Accessibility
 # Accessibility
 
 <p class="md-block-lead md-text-color-RO-donkerblauw" markdown="1">
-  The CoronaMelder app should be accessible to everyone. From its very first design accessibility has been taken into account, with the help of experts and experience experts. Yet the app might not be as accessible to you. Are you unable to use the app well? Let us know by emailing <a href="mailto:coronamelder@minvws.nl?subject={{ site.data.translations.accessibility-in-app-email-subject[page.lang] }}">coronamelder@minvws.nl</a>.
+  The CoronaMelder app should be accessible to everyone. From its very first design accessibility has been taken into account, with the help of experts and experience experts. Yet the app might not be as accessible to you. Are you unable to use the app well? Let us know by emailing <a href="mailto:coronamelder@minvws.nl?subject={{ site.data.translations.accessibility-in-app-email-subject[page.lang] }}" target="_blank">.
 </p>
 
 The CoronaMelder app follows the [Web Content Accessibility Guidelines (WCAG) 2.1](https://www.w3.org/TR/2018/REC-WCAG21-20180605/) on level AA as set out in the European standard EN 301 549. If this European standard is updated with specific guidelines for mobile applications, we will follow them.


### PR DESCRIPTION
@anneke this is a resubmission of the changes as per PR #277 (which I will close).

By appending the subject line, we ease the user from having to think about the subject line and can focus on the message.

If unchanged, it also gives a clear indication to the recipient of the email on the context of the email message from the subject itself.

A rule-based system could also be created for such emails to be forwarded as required, or placed in a particular folder, helping the recipient who has to process the Corona Melder inbox.

Used the translations.yml to set the EN and NL translation strings, so that they can be centrally modified and added as needed.