### PR TITLE
Remove slider image alt content

### DIFF
--- a/_data/translations.yml
+++ b/_data/translations.yml
@@ -226,19 +226,19 @@ info-slides:
     -
       image: graphic-app-logo
       title: CoronaMelder
-      alt: CoronaMelder
+      alt: 
     -
       image: graphic-outside-bicycle
       title: Bescherm je vrienden, familie en de rest van Nederland
       content: |
         De app waarschuwt nadat je in de buurt bent geweest van iemand met corona. Zo kun jij voorkomen dat je de mensen in je omgeving besmet.
-      alt: Bescherm je vrienden, familie en de rest van Nederland
+      alt: 
     -
       image: graphic-app-notification
       title: Je krijgt een melding <u>nadat</u> je extra kans op besmetting hebt gelopen.
       content: |
        Dit gebeurt als je minstens 15 minuten dicht bij iemand bent geweest die later corona blijkt te hebben. Deze persoon moet ook de app gebruiken.
-      alt: Je krijgt een melding nadat je extra kans op besmetting hebt gelopen
+      alt: 
     -
       image: graphic-app-bluetooth
       title: CoronaMelder gebruikt Bluetooth,<br> <u>geen</u> locatiegegevens
@@ -246,35 +246,36 @@ info-slides:
         De app ziet via Bluetooth of je dicht bij iemand was.
         Hoe dichterbij, hoe sterker het Bluetooth-signaal.
         De app weet niet waar je was en wie je bent.
-      alt: CoronaMelder gebruikt Bluetooth, geen locatiegegevens.
+      alt: 
     -
       image: graphic-bicycle
       title: <span class="md-highlight">Voorbeeld</span><br> Fietste iemand voorbij? Dan krijg je later geen melding
       content: |
         Het Bluetooth-signaal was sterk genoeg omdat jullie dicht bij elkaar waren. Dit duurde alleen zo kort dat de kans op besmetting heel laag is.
-      alt: Fietste iemand voorbij? Dan krijg je later geen melding
+      alt: 
     -
       image: graphic-train
       title: <span class="md-highlight">Voorbeeld</span><br> Zat je dicht bij iemand in de trein? Dan kun je later wel een melding krijgen
       content: |
        Het bluetooth-signaal was sterk genoeg en jullie waren langere tijd dicht bij elkaar in de buurt.
+      alt: 
   en:
     -
       image: graphic-app-logo
       title: CoronaMelder
-      alt: CoronaMelder
+      alt: 
     -
       image: graphic-outside-bicycle
       title: Help protect your friends, your family and the whole community
       content: |
         The app will warn you if you have been near someone with coronavirus. This means you can stop yourself from infecting the people around you.
-      alt: Help protect your friends, your family and the whole community
+      alt: 
     -
       image: graphic-app-notification
       title: You will get a notification if there is a risk that you have been exposed to the virus
       content: |
         If you have been near someone who later tests positive for coronavirus, and you were near them for at least 15 minutes, you will get a notification. But only if that person is also using the app.
-      alt: You will get a notification if there is a risk that you have been exposed to the virus
+      alt:
     -
       image: graphic-app-bluetooth
       title: The CoronaMelder app uses Bluetooth, <br> <u>not</u> location data
@@ -282,19 +283,19 @@ info-slides:
         Using Bluetooth, the app sees if you've been near someone. 
         The closer you've been, the stronger the Bluetooth signal. 
         The app doesn't know who you are or where you've been.
-      alt: The CoronaMelder app uses Bluetooth,not location data
+      alt: 
     -
       image: graphic-bicycle
       title: <span class="md-highlight">Example</span><br> Did someone cycle past you? Then you will not get a notification later.
       content: |
         The Bluetooth signal was strong because you were near each other. But only for a very short time. This means your risk of infection is very low.
-      alt: Did someone cycle past you? Then you will not get a notification later.
+      alt: 
     -
       image: graphic-train
       title: <span class="md-highlight">Example</span><br> Did you sit near someone on the train? You could get a notification later.
       content: |
         The Bluetooth signal was strong enough and you were near each other for a longer period of time.
-      alt:  Did you sit near someone on the train? You could get a notification later
+      alt: 
 
 # Footer translations
 


### PR DESCRIPTION
@hidde inspected some recently applied fixes and pointed us to the fact that we mistakenly added content for alt attributes on images in the slider. (they just add noise for those with screenreaders). The slider was going to be removed in the new design for the homepage, but in case we keep it, this PR corrects that mistake!

Possibly this PR can be deleted.