### PR TITLE
add missing 'head-social-og-site_name' translation

### DIFF
--- a/_data/translations.yml
+++ b/_data/translations.yml
@@ -1,6 +1,9 @@
 head-app-name:
   nl: CoronaMelder
   en: CoronaMelder
+head-social-og-site_name:
+  nl: CoronaMelder
+  en: CoronaMelder
 head-social-og-title:
   nl: CoronaMelder wordt getest in de praktijk
   en: CoronaMelder is being tested in the field


### PR DESCRIPTION
Het `og:site_name` meta element is leeg in de Engelse en Nederlandse site, omdat `head-social-og-site_name` niet in de vertaaltabel stond.