### PR TITLE
Fix README text and formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository contains the source files of the official website for the Dutch COVID-19 Notification App CoronaMelder and is available at [coronamelder.nl](https://coronamelder.nl)
 
 
-## Goals of the website
+## Status
 
 Please join the Slack channel and check out the kanban board for the latest status. 
 
@@ -62,21 +62,6 @@ The hosting requirements are defined elsewhere.
 
 There is a nice story to be told about how the website was created. It all started with a high-level traffic light dashboard idea to indicate the status of the project. This idea was adopted by the community, that let this project evolve (via Github and Slack) from the traffic dashboard to what is now the project website-to-be. The whole process can be followed via [Channel notificatie-app-website](https://app.slack.com/client/T68FXPFQV/C0151NCG140) ([join Slack workspace here](https://doemee.codefor.nl/)). 
 Please ping any of the people involved via Slack if you are interested in writing an article about this.
-
-
-## Honorable mentions and gratitude 
-
-Shout out to all volunteers that helped out, among which: Harrie Kuipers (project lead), Paul Wagener (initial HTML implementation), Benjamin W. Broersma (tech lead, HTML implementation of the version 0.6 design, translatable templates via markdown), Anouschka Scholten (UX research questionnaire among 500+ people and interaction design feedback website), Arian van van Putten (helped out with Github issues and useful comments) and Bart Lenstra (designs in Figma). Also involved were Laura Engelshove, Cas Zeegers, Nelleke Harmse, Ruben Vandenbussche, Ruben Ahuluheluw, Joost Soeterbroek. 
-
-The main objective of coronamelder.nl is to activate Dutch citizens to download and use CoronaMelder to reduce COVID-19 infections. Therefore, the site meets the information needs of visitors. Mainly:
-
-* Explain why the app is needed, what the app does and how CoronaMelder works
-* Give answers to frequently asked questions about CoronaMelder and debunk misconceptions
-* Provide the current privacy statement, accessibility statement, colophon and version information of CoronaMelder
-* Refer to the iOS App Store and Android Google Play Store to install CoronaMelder on a smartphone
-* Offer contact channels for other questions about CoronaMelder
-
-See also the [Requirements and design principles](https://github.com/minvws/nl-covid19-notification-app-website/blob/master/README.requirements.md) for the website.
 
 
 ## Disclaimer

--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
-About
----------------------
+## About
 
 This repository contains the source files of the official website for the Dutch COVID-19 Notification App CoronaMelder and is available at [coronamelder.nl](https://coronamelder.nl)
 
 
-Goals of the website
----------------------
+## Goals of the website
+
 Please join the Slack channel and check out the kanban board for the latest status. 
 
-Goals of the website:
----------------------
+
+## Goals of the website:
 
 Before the app is finished, the main goal is to **inform** visitors:
 * Goal 1: Provide a clear overview of which areas the team is working on / what the project status is.
@@ -26,8 +25,8 @@ After the app is finished:
 
 * **Goal after finished: Convince** people to download the app
 
-Design principles
------------------
+
+## Design principles
 
 * Design principle 1: Clarity and usability over eye candy
 * Design principle 2: Test the results on the target group, guerilla testing in the supermarket, etc. 
@@ -36,8 +35,9 @@ Design principles
 * Design principle 5: Confirm to the design principles of[  ](https://www.gebruikercentraal.nl/)[Gebruiker](https://www.gebruikercentraal.nl/)[  ](https://www.gebruikercentraal.nl/)[Centraal](https://www.gebruikercentraal.nl/).
 * Design principle 6: The website 'feels' just like the app itself (tone of voice ("je", not "u"), graphics, interaction patterns, UX design, use, etc.)
 
-Features, requirements and standards
-------------------------------------
+
+## Features, requirements and standards
+
 **Preamble:** the intended quality of the website is very high (10/10), as this will impact the number of downloads both directly (defined as a high click-through rate to the app stores) and indirectly (influencing public opinion, by taking away common misconceptions etc.). 
 * Requirement 1: Adhering to **WCAG accessibility standards** as specified in the [Accessibility document](https://github.com/minvws/nl-covid19-notification-app-coordination/blob/master/accessibility/Toegankelijkheid.md) of the app itself.
 * Requirement 2: **Download button should be easily added after launch of the app.**
@@ -57,28 +57,29 @@ Features, requirements and standards
 
 The hosting requirements are defined elsewhere.
 
-How this website came about (pinging journalists) 
-------------------------------------
+
+## How this website came about (pinging journalists) 
+
 There is a nice story to be told about how the website was created. It all started with a high-level traffic light dashboard idea to indicate the status of the project. This idea was adopted by the community, that let this project evolve (via Github and Slack) from the traffic dashboard to what is now the project website-to-be. The whole process can be followed via [Channel notificatie-app-website](https://app.slack.com/client/T68FXPFQV/C0151NCG140) ([join Slack workspace here](https://doemee.codefor.nl/)). 
 Please ping any of the people involved via Slack if you are interested in writing an article about this.
 
+
 ## Honorable mentions and gratitude 
+
 Shout out to all volunteers that helped out, among which: Harrie Kuipers (project lead), Paul Wagener (initial HTML implementation), Benjamin W. Broersma (tech lead, HTML implementation of the version 0.6 design, translatable templates via markdown), Anouschka Scholten (UX research questionnaire among 500+ people and interaction design feedback website), Arian van van Putten (helped out with Github issues and useful comments) and Bart Lenstra (designs in Figma). Also involved were Laura Engelshove, Cas Zeegers, Nelleke Harmse, Ruben Vandenbussche, Ruben Ahuluheluw, Joost Soeterbroek. 
 
 The main objective of coronamelder.nl is to activate Dutch citizens to download and use CoronaMelder to reduce COVID-19 infections. Therefore, the site meets the information needs of visitors. Mainly:
 
-- Explain why the app is needed, what the app does and how CoronaMelder works
-- Give answers to frequently asked questions about CoronaMelder and debunk misconceptions
-- Provide the current privacy statement, accessibility statement, colophon and version information of CoronaMelder
-- Refer to the iOS App Store and Android Google Play Store to install CoronaMelder on a smartphone
-- Offer contact channels for other questions about CoronaMelder
+* Explain why the app is needed, what the app does and how CoronaMelder works
+* Give answers to frequently asked questions about CoronaMelder and debunk misconceptions
+* Provide the current privacy statement, accessibility statement, colophon and version information of CoronaMelder
+* Refer to the iOS App Store and Android Google Play Store to install CoronaMelder on a smartphone
+* Offer contact channels for other questions about CoronaMelder
 
 See also the [Requirements and design principles](https://github.com/minvws/nl-covid19-notification-app-website/blob/master/README.requirements.md) for the website.
 
 
-
-Disclaimer
------------
+## Disclaimer
 
 The design and development of the website started as a volunteering project [in the community](https://minvws.github.io/nl-covid19-notification-app-community-website/). The Ministry of Health, Welfare and Sport has built the current website on the foundation created by community members.
 
@@ -91,7 +92,9 @@ Shout out to all volunteers that helped out, among which: Harrie Kuipers (projec
 
 Harrie, Bart, Cas and Laura have later been asked to finish the project on a paid basis. 
 
+
 ## Development & Contribution process 
+
 Note: rather than rely on a third party CDN or dependencies that are not part of this repository; all assets and dependencies are part of this build. Please go to [the vendor licenses directory](./vendor-licenses) for the vendor licenses.
 
 The development team works directly from this open-source repository. If you plan to propose changes, we recommend opening an issue beforehand where we can discuss your planned changes. This increases the chance that we’re able to use your contribution (or it avoids doing work if there are reasons why we wouldn't be able to use it).


### PR DESCRIPTION
Some small text- and formatting changes:

- Unify Markdown formatting of subheadings, spacing and lists
- Change wrong 'Goals of the website' heading to 'Status'
- Remove remaining old (and duplicate) 'Thank You + Requirements' section
