### PR TITLE
Include the .well-known directory in the Jekyll build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,9 +11,12 @@ sass:
   load_paths:
     - css
     - css-rtl
-    
+
+include:
+  - .well-known
+
 exclude:
-  - vendor 
+  - vendor
   - Gemfile
   - Gemfile.lock
   - README.md


### PR DESCRIPTION
Commit f072272 introduced `security.txt`, a (proposed) standard for defining security policies. This is the first thing an ethical hacker will look for when they want to report a security issue in a responsible manner (see https://github.com/minvws/nl-covid19-notification-app-backend/issues/8). The file should be served from `<domain>/.well-known/security.txt`.
However, Jekyll by default excludes dotfiles. Because of this, https://coronamelder.nl/.well-known/security.txt currently returns a 404 Not Found response.

This PR forces inclusion of the .well-known directory, so that the file will be served from the correct URL.